### PR TITLE
Add PDF metadata extraction on upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
+    "pdfjs-dist": "^3.11.174",
     "recharts": "^2.12.7",
     "react-pdf": "^7.0.0",
     "sonner": "^1.5.0",

--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useBooks } from '@/hooks/useBooks';
 import { Upload } from 'lucide-react';
+import { extractPdfMetadata } from '@/lib/pdf';
 
 interface UploadModalProps {
   isOpen: boolean;
@@ -19,13 +20,18 @@ const UploadModal = ({ isOpen, onClose }: UploadModalProps) => {
   const [author, setAuthor] = useState('');
   const [series, setSeries] = useState('');
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
     if (selectedFile && selectedFile.type === 'application/pdf') {
       setFile(selectedFile);
-      if (!title) {
+      const meta = await extractPdfMetadata(selectedFile);
+      if (meta.title) {
+        setTitle(meta.title);
+      } else if (!title) {
         setTitle(selectedFile.name.replace('.pdf', ''));
       }
+      if (meta.author) setAuthor(meta.author);
+      if (meta.series) setSeries(meta.series);
     }
   };
 

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -1,0 +1,26 @@
+import { getDocument, type PDFDocumentProxy } from 'pdfjs-dist';
+
+export interface PdfMetadata {
+  title?: string;
+  author?: string;
+  series?: string;
+}
+
+export const extractPdfMetadata = async (
+  file: File,
+): Promise<PdfMetadata> => {
+  try {
+    const arrayBuffer = await file.arrayBuffer();
+    const loadingTask = getDocument({ data: arrayBuffer });
+    const pdf: PDFDocumentProxy = await loadingTask.promise;
+    const { info } = await pdf.getMetadata();
+    pdf.destroy();
+    return {
+      title: typeof info.Title === 'string' ? info.Title : undefined,
+      author: typeof info.Author === 'string' ? info.Author : undefined,
+      series: typeof (info as any).Series === 'string' ? (info as any).Series : undefined,
+    };
+  } catch {
+    return {};
+  }
+};


### PR DESCRIPTION
## Summary
- extract metadata from PDFs using pdfjs
- use metadata to pre-fill upload form
- include pdfjs-dist as dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b20a89624832397770016f09abbb3