### PR TITLE
Fix admin user password validation

### DIFF
--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -59,6 +59,7 @@ const AdminUsers = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            minLength={6}
           />
         </div>
         <Button type="submit" disabled={loading}>


### PR DESCRIPTION
## Summary
- enforce password length in `AdminUsers` page

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cc48d05808323be7b18d92ee9edf2