### PR TITLE
Add Voyant interface route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Reader from "./pages/Reader";
 import AdminUsers from "./pages/AdminUsers";
+import VoyantUsers from "./pages/VoyantUsers";
 import Payment from "./pages/Payment";
 
 const queryClient = new QueryClient();
@@ -24,6 +25,7 @@ const App = () => (
             <Route path="/" element={<Index />} />
             <Route path="/read/:bookId" element={<Reader />} />
             <Route path="/admin/users" element={<AdminUsers />} />
+            <Route path="/voyant/users" element={<VoyantUsers />} />
             <Route path="/payment" element={<Payment />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />

--- a/src/pages/VoyantUsers.tsx
+++ b/src/pages/VoyantUsers.tsx
@@ -1,0 +1,2 @@
+import AdminUsers from './AdminUsers';
+export default AdminUsers;


### PR DESCRIPTION
## Summary
- expose a `VoyantUsers` page reusing the admin user component
- add route `/voyant/users` for seer interface

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd5e22984832394a6ce19d5e89e12