### PR TITLE
Mirror admin interface for voyant

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import Index from "./pages/Index";
+import VoyantIndex from "./pages/VoyantIndex";
 import NotFound from "./pages/NotFound";
 import Reader from "./pages/Reader";
 import AdminUsers from "./pages/AdminUsers";
@@ -23,6 +24,7 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/voyant" element={<VoyantIndex />} />
             <Route path="/read/:bookId" element={<Reader />} />
             <Route path="/admin/users" element={<AdminUsers />} />
             <Route path="/voyant/users" element={<VoyantUsers />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -51,6 +51,9 @@ const Navigation = () => {
                   <Button asChild variant="ghost" className="text-gray-700 hover:text-blue-600">
                     <Link to="/payment">Paiement</Link>
                   </Button>
+                  <Button asChild variant="ghost" className="text-gray-700 hover:text-blue-600">
+                    <Link to="/voyant/users">Utilisateurs</Link>
+                  </Button>
                 </div>
               )}
             </div>

--- a/src/pages/VoyantIndex.tsx
+++ b/src/pages/VoyantIndex.tsx
@@ -1,0 +1,2 @@
+import Index from './Index';
+export default Index;


### PR DESCRIPTION
## Summary
- add route for `/voyant` that reuses the admin dashboard
- show a link to `Utilisateurs` in the navigation for voyant users

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cd780136c83238686347fd36e6650